### PR TITLE
Fixed cpu build on the systems where no local cuda is available

### DIFF
--- a/recipe/install-liblightgbm.sh
+++ b/recipe/install-liblightgbm.sh
@@ -42,7 +42,7 @@ then
     export CUDA_COMPUTE_CABABILITY
 fi
 
-if [[ $mpi_type != None ]]
+if [[ $mpi_type != None && $build_type == "cuda" ]]
 then
     BUILD_OPTION+=" -DUSE_MPI=ON"
 fi

--- a/recipe/install-py-lightgbm.sh
+++ b/recipe/install-py-lightgbm.sh
@@ -28,7 +28,7 @@ then
     export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include -I${CUDA_HOME}/include -I${CONDA_PREFIX}/include"
 fi
 
-if [[ $mpi_type != None ]]
+if [[ $mpi_type != None && $build_type == "cuda" ]]
 then
     INSTALL_OPTION+="--mpi"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0202-Fix-for-cuda-compute-capabilities-setting.patch  #[build_type == 'cuda']
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: liblightgbm-base
@@ -38,7 +38,7 @@ outputs:
         - git >={{ git }}
       host:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
-        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi' and build_type == 'cuda']
       run:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
         - _lightgbm_select {{ lightgbm_select_version }} 
@@ -63,7 +63,7 @@ outputs:
         - {{ pin_subpackage('liblightgbm-base', exact=True) }}
         - python {{ python }}
         - setuptools {{ setuptools }}
-        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi' and build_type == 'cuda']
       run:
         - {{ pin_subpackage('liblightgbm-base', exact=True) }}
         - python {{ python }}
@@ -72,7 +72,7 @@ outputs:
         - scikit-learn
         - joblib {{ joblib }}
         - _lightgbm_select {{ lightgbm_select_version }}
-        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }}                #[mpi_type == 'openmpi' and build_type == 'cuda']
       extra:
         toolkitused: {{ cudatoolkit }}           #[build_type == 'cuda']
       test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ outputs:
   - name: liblightgbm-base
     script: install-liblightgbm.sh
     build:
-      string: {{ build_type }}_{{ mpi_type }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
+      string: {{ build_type }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
       string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_{{ mpi_type }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 {% if build_type == 'cuda' %}
       script_env:
@@ -46,7 +46,7 @@ outputs:
   - name: py-lightgbm-base
     script: install-py-lightgbm.sh
     build:
-      string: {{ build_type }}_{{ mpi_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
+      string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
       string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_{{ mpi_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 {% if build_type == 'cuda' %}
       script_env:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

I ran cpu builds for whole opence environment on M4-1 system where no local cuda is available. And the build failed on it because openmpi could not be built as it needs CUDA_HOME. We could not catch this issue so far, because wherever we ran cpu builds, those systems had local cuda and $CUDA_HOME set. So, openmpi was getting built and so LightGBM.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
