### PR TITLE
Remove python as a dependency from meta package

### DIFF
--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -7,11 +7,10 @@ package:
   version: {{ version }}
 
 build:
-  number: 1 
+  number: 2 
 
 requirements:
   run:
-    - python {{ python }}
     - liblightgbm-base {{ version }}*
     - py-lightgbm-base {{ version }}*
     - _lightgbm_select =={{ lightgbm_select_version }}*


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Remove python as a dependency from the meta package. This is a problem when there are multiple versions of python supported within the same channel, since the name of the meta package doesn't have the python version in it.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
