### PR TITLE
require cuda variant for openmpi when using cuda and openmpi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
       host:
 {% if build_type == 'cuda' %}
         - cudatoolkit {{ cudatoolkit }}
-        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda*   #[mpi_type == 'openmpi']
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}
@@ -68,7 +68,8 @@ outputs:
         - python {{ python }}
         - setuptools {{ setuptools }}
 {% if build_type == 'cuda' %}
-        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda*   #[mpi_type == 'openmpi']
+        - cudatoolkit {{ cudatoolkit }}
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}
@@ -81,12 +82,11 @@ outputs:
         - joblib {{ joblib }}
         - _lightgbm_select {{ lightgbm_select_version }}
 {% if build_type == 'cuda' %}
-        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda*   #[mpi_type == 'openmpi']
+        - cudatoolkit {{ cudatoolkit }}
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}
-      extra:
-        toolkitused: {{ cudatoolkit }}           #[build_type == 'cuda']
       test:
       imports:
         - lightgbm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0202-Fix-for-cuda-compute-capabilities-setting.patch  #[build_type == 'cuda']
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: liblightgbm-base
@@ -37,8 +37,12 @@ outputs:
         - libuv
         - git >={{ git }}
       host:
-        - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
+{% if build_type == 'cuda' %}
+        - cudatoolkit {{ cudatoolkit }}
+        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+{% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+{% endif %}
       run:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
         - _lightgbm_select {{ lightgbm_select_version }} 
@@ -63,7 +67,11 @@ outputs:
         - {{ pin_subpackage('liblightgbm-base', exact=True) }}
         - python {{ python }}
         - setuptools {{ setuptools }}
+{% if build_type == 'cuda' %}
+        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+{% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+{% endif %}
       run:
         - {{ pin_subpackage('liblightgbm-base', exact=True) }}
         - python {{ python }}
@@ -72,7 +80,11 @@ outputs:
         - scikit-learn
         - joblib {{ joblib }}
         - _lightgbm_select {{ lightgbm_select_version }}
+{% if build_type == 'cuda' %}
+        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+{% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
+{% endif %}
       extra:
         toolkitused: {{ cudatoolkit }}           #[build_type == 'cuda']
       test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
       host:
 {% if build_type == 'cuda' %}
         - cudatoolkit {{ cudatoolkit }}
-        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}
@@ -68,7 +68,7 @@ outputs:
         - python {{ python }}
         - setuptools {{ setuptools }}
 {% if build_type == 'cuda' %}
-        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}
@@ -81,7 +81,7 @@ outputs:
         - joblib {{ joblib }}
         - _lightgbm_select {{ lightgbm_select_version }}
 {% if build_type == 'cuda' %}
-        - openmpi {{ openmpi }} cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
+        - openmpi {{ openmpi }} *cuda{{ cudatoolkit }}*   #[mpi_type == 'openmpi']
 {% else %}
         - openmpi {{ openmpi }}                #[mpi_type == 'openmpi']
 {% endif %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Currently, LightGBM can require cuda and/or openmpi. Since openmpi has a cuda variant as well, this PR will ensure that the proper cuda variant is selected for the lightgbm cuda variant being used.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
