### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins which are no longer needed

### DIFF
--- a/recipe/install-liblightgbm.sh
+++ b/recipe/install-liblightgbm.sh
@@ -33,18 +33,11 @@ then
     find /usr/include -name cublas*.h -exec ln -s "{}" "$CONDA_PREFIX/include/" ';'
     export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include -I${CUDA_HOME}/include -I${CONDA_PREFIX}/include"
 
-    if [[ "${ARCH}" == 'ppc64le' ]]
-    then 
-        CUDA_COMPUTE_CABABILITY="6.0 7.0 7.5"
-    else
-        CUDA_COMPUTE_CABABILITY="6.0 6.1 7.0 7.5"
-    fi
-
-    CUDA_VERSION="${cudatoolkit%.*}"
-    if [[ $CUDA_VERSION == '11' ]]; then
-        CUDA_COMPUTE_CABABILITY+=' 8.0'
-    fi
-    export CUDA_COMPUTE_CABABILITY
+    CUDA_COMPUTE_CAPABILITY=${cuda_levels//,/ }
+    # LightGBM doesn't work with cuda capability 3.7. So, removing it.
+    export CUDA_COMPUTE_CAPABILITY=${CUDA_COMPUTE_CAPABILITY//3.7 /}
+    echo $CUDA_COMPUTE_CABABILITY
+   
 fi
 
 if [[ $mpi_type != None ]]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,9 @@ outputs:
         - make
         - libuv
         - git >={{ git }}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
       host:
 {% if build_type == 'cuda' %}
         - cudatoolkit {{ cudatoolkit }}
@@ -65,6 +68,9 @@ outputs:
 {% else %}
         - openmpi {{ openmpi }}          #[mpi_type == 'openmpi']
 {% endif %}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
       run:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
       run_constrained:
@@ -111,6 +117,9 @@ outputs:
         - {{ compiler('cxx') }}               #[mpi_type != 'system']
         - cmake >=3.16
         - make
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
       host:
         - {{ pin_subpackage('liblightgbm', exact=True) }}
         - python {{ python }}
@@ -121,6 +130,9 @@ outputs:
 {% else %}
         - openmpi {{ openmpi }}          #[mpi_type == 'openmpi']
 {% endif %}
+        # Use pins to control cos6/cos7 match
+        - libgcc-ng  {{ libgcc }}         # [x86_64 and c_compiler_version == "7.2.*"]
+        - libstdcxx-ng  {{ libstdcxx }}   # [x86_64 and c_compiler_version == "7.2.*"]
       run:
         - {{ pin_subpackage('liblightgbm', exact=True) }}
         - python {{ python }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0202-Fix-for-cuda-compute-capabilities-setting.patch  #[build_type == 'cuda']
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("liblightgbm", max_pin="x.x.x") }}
 
@@ -58,9 +58,6 @@ outputs:
         - make
         - libuv
         - git >={{ git }}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       host:
 {% if build_type == 'cuda' %}
         - cudatoolkit {{ cudatoolkit }}
@@ -68,9 +65,6 @@ outputs:
 {% else %}
         - openmpi {{ openmpi }}          #[mpi_type == 'openmpi']
 {% endif %}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       run:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
       run_constrained:
@@ -117,9 +111,6 @@ outputs:
         - {{ compiler('cxx') }}               #[mpi_type != 'system']
         - cmake >=3.16
         - make
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       host:
         - {{ pin_subpackage('liblightgbm', exact=True) }}
         - python {{ python }}
@@ -130,9 +121,6 @@ outputs:
 {% else %}
         - openmpi {{ openmpi }}          #[mpi_type == 'openmpi']
 {% endif %}
-        # Use pins to control cos6/cos7 match
-        - libgcc-ng  {{ libgcc }}
-        - libstdcxx-ng  {{ libstdcxx }}
       run:
         - {{ pin_subpackage('liblightgbm', exact=True) }}
         - python {{ python }}

--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -2,9 +2,14 @@ tests:
   - name: Setup LightGBM Tests
     command: |
         # Get the LightGBM repo, which contains the tests
-
+        conda install -y git
         git clone -b v$(python -c "import lightgbm as lgbm; print(lgbm.__version__)") https://github.com/microsoft/LightGBM
-        conda install -y pytest psutil scikit-learn pandas matplotlib scipy graphviz
+        conda install -y pytest psutil scikit-learn pandas matplotlib scipy
+        PYTHON_VER=$(python -c 'import platform; print(platform.python_version())')
+        if [[ ! "$PYTHON_VER" =~ "3.9" ]]
+        then
+            conda install -y graphviz # graphviz doesn't install with python3.9
+        fi 
  
   - name: Run LightGBM tests
     command: |

--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -8,7 +8,7 @@ tests:
         PYTHON_VER=$(python -c 'import platform; print(platform.python_version())')
         if [[ ! "$PYTHON_VER" =~ "3.9" ]]
         then
-            conda install -y graphviz # graphviz doesn't install with python3.9
+            conda install -y graphviz        # graphviz doesn't install with python3.9
         fi 
  
   - name: Run LightGBM tests


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
