### PR TITLE
Resolve CUDA Tree Learner was not enabled build error

### DIFF
--- a/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
+++ b/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
@@ -102,7 +102,7 @@ requires-python = ">=3.7"
 include-package-data = true
 
 [tool.setuptools.package-data]
-lightgbm = ["lib_lightgbm.so", "bin/*", "lib/*"]
+lightgbm = ["lib_lightgbm.so","lib/*"]
 EOF
 
 # Install with setuptools

--- a/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
+++ b/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
@@ -14,32 +14,99 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # *****************************************************************
+set -ex
 
 pushd ${SRC_DIR}
+
 export CMAKE_PREFIX_PATH=$PREFIX
 export CMAKE_LIBRARY_PATH=$PREFIX/lib:$BUILD_PREFIX/lib:$CMAKE_LIBRARY_PATH
 
-INSTALL_OPTION=""
+# Default CMake options
+CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=$PREFIX \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH=$PREFIX"
 
-if [[ $build_type == "cuda" ]]
-then
-    INSTALL_OPTION="--config-settings=cmake.define.USE_CUDA=ON "
+# CUDA build
+if [[ $build_type == "cuda" ]]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DUSE_CUDA=ON"
+
     export CUDACXX=$CUDA_HOME/bin/nvcc
     export CMAKE_CUDA_HOST_COMPILER=${GXX}
 
-    # Create symlinks of cublas headers into CONDA_PREFIX
+    # Make sure CUDA headers are available to cmake
     mkdir -p $CONDA_PREFIX/include
-    find /usr/include -name cublas*.h -exec ln -s "{}" "$CONDA_PREFIX/include/" ';'
+    if [ -d "$CUDA_HOME/include" ]; then
+        ln -sf $CUDA_HOME/include/cublas*.h $CONDA_PREFIX/include/ || true
+    fi
+
     export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include -I${CUDA_HOME}/include -I${CONDA_PREFIX}/include"
+else
+    CMAKE_ARGS="$CMAKE_ARGS -DUSE_CUDA=OFF"
 fi
 
-if [[ $mpi_type != None ]]
-then
-    INSTALL_OPTION+="--config-settings=cmake.define.USE_MPI=ON"
+# MPI build
+if [[ $mpi_type != None ]]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DUSE_MPI=ON"
+else
+    CMAKE_ARGS="$CMAKE_ARGS -DUSE_MPI=OFF"
 fi
 
-echo $INSTALL_OPTION
+echo "CMake configuration: $CMAKE_ARGS"
 
-pip install lightgbm==${PKG_VERSION} $INSTALL_OPTION --no-deps
+# Build and install C++ core
+mkdir -p build
+cd build
+
+cmake ${SRC_DIR} $CMAKE_ARGS
+cmake --build . --target _lightgbm -- -j${CPU_COUNT}
+cmake --build . --target install -- -j${CPU_COUNT}
+
+cd ..
+
+# Now lib_lightgbm.so should exist
+LIB_PATH=${PREFIX}/lib/lib_lightgbm.so
+if [[ ! -f "$LIB_PATH" ]]; then
+    echo "ERROR: lib_lightgbm.so not found in ${PREFIX}/lib/"
+    exit 1
+fi
+
+# Copy into python package so wheel contains it
+mkdir -p ${SRC_DIR}/python-package/lightgbm
+cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/
+
+# Also copy to bin/ and lib/ for safety (matches LightGBM's search paths)
+mkdir -p ${SRC_DIR}/python-package/lightgbm/bin
+mkdir -p ${SRC_DIR}/python-package/lightgbm/lib
+cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/bin/
+cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/lib/
+
+cp "$LIB_PATH" ${SRC_DIR}/python-package/
+
+echo "Installing Python package with setuptools..."
+cd python-package
+
+# Patch pyproject.toml to avoid scikit-build-core
+cat > pyproject.toml <<EOF
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lightgbm"
+version = "4.2.0"
+description = "LightGBM Python Package"
+authors = [{ name = "Microsoft Corporation" }]
+requires-python = ">=3.7"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+lightgbm = ["lib_lightgbm.so", "bin/*", "lib/*"]
+EOF
+
+# Install with setuptools
+$PYTHON -m pip install . --no-build-isolation --no-deps -v
 
 popd
+

--- a/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
+++ b/lightgbm-4.2.0/recipe/install-py-lightgbm-x86.sh
@@ -21,12 +21,10 @@ pushd ${SRC_DIR}
 export CMAKE_PREFIX_PATH=$PREFIX
 export CMAKE_LIBRARY_PATH=$PREFIX/lib:$BUILD_PREFIX/lib:$CMAKE_LIBRARY_PATH
 
-# Default CMake options
 CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=$PREFIX \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=$PREFIX"
 
-# CUDA build
 if [[ $build_type == "cuda" ]]; then
     CMAKE_ARGS="$CMAKE_ARGS -DUSE_CUDA=ON"
 
@@ -40,15 +38,11 @@ if [[ $build_type == "cuda" ]]; then
     fi
 
     export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include -I${CUDA_HOME}/include -I${CONDA_PREFIX}/include"
-else
-    CMAKE_ARGS="$CMAKE_ARGS -DUSE_CUDA=OFF"
 fi
 
 # MPI build
 if [[ $mpi_type != None ]]; then
     CMAKE_ARGS="$CMAKE_ARGS -DUSE_MPI=ON"
-else
-    CMAKE_ARGS="$CMAKE_ARGS -DUSE_MPI=OFF"
 fi
 
 echo "CMake configuration: $CMAKE_ARGS"
@@ -73,13 +67,8 @@ fi
 # Copy into python package so wheel contains it
 mkdir -p ${SRC_DIR}/python-package/lightgbm
 cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/
-
-# Also copy to bin/ and lib/ for safety (matches LightGBM's search paths)
-mkdir -p ${SRC_DIR}/python-package/lightgbm/bin
 mkdir -p ${SRC_DIR}/python-package/lightgbm/lib
-cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/bin/
 cp "$LIB_PATH" ${SRC_DIR}/python-package/lightgbm/lib/
-
 cp "$LIB_PATH" ${SRC_DIR}/python-package/
 
 echo "Installing Python package with setuptools..."

--- a/lightgbm-4.2.0/recipe/meta.yaml
+++ b/lightgbm-4.2.0/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 0001-Fixed-CVE-2024-43598.patch
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage("liblightgbm", max_pin="x.x.x") }}
 


### PR DESCRIPTION
Encountered following error with cuda build
```
LightGBMError: CUDA Tree Learner was not enabled in this build.
Please recompile with CMake option -DUSE_CUDA=1
when called with {'device':'cuda'}
```

Resolved it using the following approach.
```
mkdir build && cd build
cmake -DUSE_CUDA=1 ..
make -j$(nproc)
cd ../python-package
pip install . 
```
and also Patched pyproject.toml to bypass scikit-build-core and fall back to setuptools. This ensures the LightGBM Python package builds correctly with the shared library included.